### PR TITLE
parent_tasks, child_tasksのテーブルを踏まえてテーブルを設計

### DIFF
--- a/SQL/create.sql
+++ b/SQL/create.sql
@@ -6,7 +6,7 @@ use team_weakly_report;
 
 /*
 progressは0~100で、100になったら完了とする
-tasksテーブルのprogressから集計する
+parent_tasksテーブルのprogressから集計する
  */
 
 CREATE TABLE projects (
@@ -42,15 +42,14 @@ CREATE TABLE user_project (
 );
 
 
-
-CREATE TABLE tasks (
+/*
+progressはchild_tasksのprogressから集計する
+ */
+CREATE TABLE parent_tasks (
     project_id INT,
     user_id INT,
     id INT,
-    date DATE NOT NULL,
-    learning_time INT NOT NULL,
     title VARCHAR(128) NOT NULL,
-    content TEXT,
     progress INT DEFAULT 0 NOT NULL,
     created_at TIMESTAMP,
     PRIMARY KEY (project_id, user_id, id),
@@ -58,6 +57,20 @@ CREATE TABLE tasks (
     FOREIGN KEY (project_id) REFERENCES projects (id)
 );
 
+/*
+contentにtaskの詳細を記入
+ */
+CREATE TABLE child_tasks (
+    project_id INT,
+    user_id INT,
+    parent_task_id INT,
+    title VARCHAR(128) NOT NULL,
+    content TEXT,
+    progress INT DEFAULT 0 NOT NULL,
+    created_at TIMESTAMP,
+    PRIMARY KEY (project_id, user_id, parent_task_id, id),
+    FOREIGN KEY (project_id, user_id, parent_task_id) REFERENCES parent_tasks (project_id, user_id, id)
+);
 
 /*
 statusテーブル name候補
@@ -67,6 +80,7 @@ completed
 pending : 評価待ち
 evaluated
  */
+
 CREATE TABLE status(
     id INT PRIMARY KEY,
     name VARCHAR(128) NOT NULL,
@@ -80,15 +94,19 @@ CREATE TABLE task_status (
     status_id INT,
     isStatus BOOLEAN DEFAULT FALSE,
     primary key (project_id, user_id, task_id, status_id),
-    FOREIGN KEY (project_id, user_id, task_id) REFERENCES tasks (project_id, user_id, id),
+    FOREIGN KEY (project_id, user_id, task_id) REFERENCES child_tasks (project_id, user_id, parent_task_id, id),
     FOREIGN KEY (status_id) REFERENCES status (id)
 );
+
 
 /*
 メンバーのタスク評価項目を全て完了するとevaluationsテーブルに1行追加する
 ユーザーの総数を取得し
 evaluationsテーブルを使って、タスクの評価が完了したユーザーの総数を取得する
 evaluations評価が完了すると、isEvaluationをTRUEにする
+
+evaluationsテーブルのisEvaluationがTRUEにする条件
+メンバー全員が評価を完了した場合
  */
 
 CREATE TABLE evaluations(
@@ -97,9 +115,10 @@ CREATE TABLE evaluations(
     task_id INT,
     user_id INT,
     isEvaluated BOOLEAN DEFAULT FALSE,
+    comment VARCHAR(255),
     created_at TIMESTAMP,
     PRIMARY KEY (project_id, task_user_id, task_id, user_id),
-    FOREIGN KEY (project_id, task_user_id, task_id) REFERENCES tasks (project_id, user_id, id),
+    FOREIGN KEY (project_id, user_id, task_id) REFERENCES child_tasks (project_id, user_id, parent_task_id, id),
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
@@ -134,35 +153,12 @@ CREATE TABLE evaluation_tags(
     task_id INT,
     tag_name_id INT,
     PRIMARY KEY (project_id, task_user_id, task_id, tag_name_id),
-    FOREIGN KEY (project_id, task_user_id, task_id) REFERENCES tasks (project_id, user_id, id),
+    FOREIGN KEY (project_id, user_id, task_id) REFERENCES child_tasks (project_id, user_id, parent_task_id, id),
     FOREIGN KEY (tag_name_id) REFERENCES tags(id)
 );
 
--- scoreは各人で初期値に+1ポイント持っておくようにする
-
 /*
-evaluationsテーブルのisEvaluationがTRUEにする条件
-メンバー全員が評価を完了した場合
-レコード数がプロジェクトメンバーの数 * 3以上になっている
- */
-
-CREATE TABLE scores (
-    project_id INT,
-    task_id INT,
-    task_user_id INT,
-    user_id INT,
-    tag_name_id INT,
-    PRIMARY KEY (project_id, task_user_id, task_id, user_id, tag_name_id),
-    score INT DEFAULT 1 NOT NULL,
-    created_at TIMESTAMP,
-    Foreign Key (project_id, task_user_id, task_id) REFERENCES tasks (project_id, user_id, id),
-    Foreign Key (user_id) REFERENCES users (id),
-    Foreign Key (tag_name_id) REFERENCES tags(id)
-);
-
-
-/*
-以降はadvanced
+advanced 子タスクへのコメント
  */
 
 CREATE TABLE comments (
@@ -173,7 +169,7 @@ CREATE TABLE comments (
     comment TEXT NOT NULL,
     created_at TIMESTAMP,
     PRIMARY KEY (project_id, task_user_id, task_id, user_id),
-    FOREIGN KEY (project_id, task_user_id, task_id) REFERENCES tasks (project_id, user_id, id),
+    FOREIGN KEY (project_id, task_user_id, task_id) REFERENCES parent_tasks (project_id, user_id, id),
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
 

--- a/SQL/create.sql
+++ b/SQL/create.sql
@@ -1,5 +1,5 @@
 -- 2回目以降コメントアウトして実行するとデバッグが楽になります
--- drop database team_weakly_report;
+drop database team_weakly_report;
 
 create database team_weakly_report;
 use team_weakly_report;
@@ -64,6 +64,7 @@ CREATE TABLE child_tasks (
     project_id INT,
     user_id INT,
     parent_task_id INT,
+    id INT,
     title VARCHAR(128) NOT NULL,
     content TEXT,
     progress INT DEFAULT 0 NOT NULL,
@@ -90,11 +91,12 @@ CREATE TABLE status(
 CREATE TABLE task_status (
     project_id INT,
     user_id INT,
+    parent_task_id INT,
     task_id INT,
     status_id INT,
     isStatus BOOLEAN DEFAULT FALSE,
     primary key (project_id, user_id, task_id, status_id),
-    FOREIGN KEY (project_id, user_id, task_id) REFERENCES child_tasks (project_id, user_id, parent_task_id, id),
+    FOREIGN KEY (project_id, user_id, parent_task_id,task_id) REFERENCES child_tasks (project_id, user_id, parent_task_id, id),
     FOREIGN KEY (status_id) REFERENCES status (id)
 );
 
@@ -112,13 +114,12 @@ evaluationsテーブルのisEvaluationがTRUEにする条件
 CREATE TABLE evaluations(
     project_id INT,
     task_user_id INT,
+    parent_task_id INT,
     task_id INT,
     user_id INT,
-    isEvaluated BOOLEAN DEFAULT FALSE,
-    comment VARCHAR(255),
     created_at TIMESTAMP,
-    PRIMARY KEY (project_id, task_user_id, task_id, user_id),
-    FOREIGN KEY (project_id, user_id, task_id) REFERENCES child_tasks (project_id, user_id, parent_task_id, id),
+    PRIMARY KEY (project_id, task_user_id, parent_task_id, task_id, user_id),
+    FOREIGN KEY (project_id, user_id, parent_task_id, task_id) REFERENCES child_tasks (project_id, user_id, parent_task_id, id),
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
@@ -145,15 +146,18 @@ CREATE TABLE tags (
 
 /*
 evaluation_tagsテーブルを使って、評価して欲しいタスクを設定する
-
  */
 CREATE TABLE evaluation_tags(
     project_id INT,
     task_user_id INT,
+    parent_task_id INT,
     task_id INT,
+    user_id INT,
     tag_name_id INT,
-    PRIMARY KEY (project_id, task_user_id, task_id, tag_name_id),
-    FOREIGN KEY (project_id, user_id, task_id) REFERENCES child_tasks (project_id, user_id, parent_task_id, id),
+    isEvaluated BOOLEAN DEFAULT FALSE,
+    comment VARCHAR(255),
+    PRIMARY KEY (project_id, task_user_id, parent_task_id, task_id, user_id, tag_name_id),
+    FOREIGN KEY (project_id, task_user_id, parent_task_id, task_id, user_id) REFERENCES evaluations (project_id, task_user_id, parent_task_id, task_id, user_id),
     FOREIGN KEY (tag_name_id) REFERENCES tags(id)
 );
 

--- a/SQL/exe.sql
+++ b/SQL/exe.sql
@@ -1,12 +1,12 @@
 -- 2回目以降コメントアウトして実行するとデバッグが楽になります
--- drop database team_weakly_report;
+drop database team_weakly_report;
 
 create database team_weakly_report;
 use team_weakly_report;
 
 /*
 progressは0~100で、100になったら完了とする
-tasksテーブルのprogressから集計する
+parent_tasksテーブルのprogressから集計する
  */
 
 CREATE TABLE projects (
@@ -42,15 +42,14 @@ CREATE TABLE user_project (
 );
 
 
-
-CREATE TABLE tasks (
+/*
+progressはchild_tasksのprogressから集計する
+ */
+CREATE TABLE parent_tasks (
     project_id INT,
     user_id INT,
     id INT,
-    date DATE NOT NULL,
-    learning_time INT NOT NULL,
     title VARCHAR(128) NOT NULL,
-    content TEXT,
     progress INT DEFAULT 0 NOT NULL,
     created_at TIMESTAMP,
     PRIMARY KEY (project_id, user_id, id),
@@ -58,6 +57,21 @@ CREATE TABLE tasks (
     FOREIGN KEY (project_id) REFERENCES projects (id)
 );
 
+/*
+contentにtaskの詳細を記入
+ */
+CREATE TABLE child_tasks (
+    project_id INT,
+    user_id INT,
+    parent_task_id INT,
+    id INT,
+    title VARCHAR(128) NOT NULL,
+    content TEXT,
+    progress INT DEFAULT 0 NOT NULL,
+    created_at TIMESTAMP,
+    PRIMARY KEY (project_id, user_id, parent_task_id, id),
+    FOREIGN KEY (project_id, user_id, parent_task_id) REFERENCES parent_tasks (project_id, user_id, id)
+);
 
 /*
 statusテーブル name候補
@@ -67,6 +81,7 @@ completed
 pending : 評価待ち
 evaluated
  */
+
 CREATE TABLE status(
     id INT PRIMARY KEY,
     name VARCHAR(128) NOT NULL,
@@ -76,30 +91,35 @@ CREATE TABLE status(
 CREATE TABLE task_status (
     project_id INT,
     user_id INT,
+    parent_task_id INT,
     task_id INT,
     status_id INT,
     isStatus BOOLEAN DEFAULT FALSE,
     primary key (project_id, user_id, task_id, status_id),
-    FOREIGN KEY (project_id, user_id, task_id) REFERENCES tasks (project_id, user_id, id),
+    FOREIGN KEY (project_id, user_id, parent_task_id,task_id) REFERENCES child_tasks (project_id, user_id, parent_task_id, id),
     FOREIGN KEY (status_id) REFERENCES status (id)
 );
+
 
 /*
 メンバーのタスク評価項目を全て完了するとevaluationsテーブルに1行追加する
 ユーザーの総数を取得し
 evaluationsテーブルを使って、タスクの評価が完了したユーザーの総数を取得する
 evaluations評価が完了すると、isEvaluationをTRUEにする
+
+evaluationsテーブルのisEvaluationがTRUEにする条件
+メンバー全員が評価を完了した場合
  */
 
 CREATE TABLE evaluations(
     project_id INT,
     task_user_id INT,
+    parent_task_id INT,
     task_id INT,
     user_id INT,
-    isEvaluated BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP,
-    PRIMARY KEY (project_id, task_user_id, task_id, user_id),
-    FOREIGN KEY (project_id, task_user_id, task_id) REFERENCES tasks (project_id, user_id, id),
+    PRIMARY KEY (project_id, task_user_id, parent_task_id, task_id, user_id),
+    FOREIGN KEY (project_id, user_id, parent_task_id, task_id) REFERENCES child_tasks (project_id, user_id, parent_task_id, id),
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
@@ -126,43 +146,23 @@ CREATE TABLE tags (
 
 /*
 evaluation_tagsテーブルを使って、評価して欲しいタスクを設定する
-
  */
 CREATE TABLE evaluation_tags(
     project_id INT,
     task_user_id INT,
+    parent_task_id INT,
     task_id INT,
+    user_id INT,
     tag_name_id INT,
-    PRIMARY KEY (project_id, task_user_id, task_id, tag_name_id),
-    FOREIGN KEY (project_id, task_user_id, task_id) REFERENCES tasks (project_id, user_id, id),
+    isEvaluated BOOLEAN DEFAULT FALSE,
+    comment VARCHAR(255),
+    PRIMARY KEY (project_id, task_user_id, parent_task_id, task_id, user_id, tag_name_id),
+    FOREIGN KEY (project_id, task_user_id, parent_task_id, task_id, user_id) REFERENCES evaluations (project_id, task_user_id, parent_task_id, task_id, user_id),
     FOREIGN KEY (tag_name_id) REFERENCES tags(id)
 );
 
--- scoreは各人で初期値に+1ポイント持っておくようにする
-
 /*
-evaluationsテーブルのisEvaluationがTRUEにする条件
-メンバー全員が評価を完了した場合
-レコード数がプロジェクトメンバーの数 * 3以上になっている
- */
-
-CREATE TABLE scores (
-    project_id INT,
-    task_id INT,
-    task_user_id INT,
-    user_id INT,
-    tag_name_id INT,
-    PRIMARY KEY (project_id, task_user_id, task_id, user_id, tag_name_id),
-    score INT DEFAULT 1 NOT NULL,
-    created_at TIMESTAMP,
-    Foreign Key (project_id, task_user_id, task_id) REFERENCES tasks (project_id, user_id, id),
-    Foreign Key (user_id) REFERENCES users (id),
-    Foreign Key (tag_name_id) REFERENCES tags(id)
-);
-
-
-/*
-以降はadvanced
+advanced 子タスクへのコメント
  */
 
 CREATE TABLE comments (
@@ -173,7 +173,7 @@ CREATE TABLE comments (
     comment TEXT NOT NULL,
     created_at TIMESTAMP,
     PRIMARY KEY (project_id, task_user_id, task_id, user_id),
-    FOREIGN KEY (project_id, task_user_id, task_id) REFERENCES tasks (project_id, user_id, id),
+    FOREIGN KEY (project_id, task_user_id, task_id) REFERENCES parent_tasks (project_id, user_id, id),
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
@@ -210,12 +210,14 @@ INSERT INTO users (id, name, email, password, avatar_url) VALUES
 (3, 'ryumasann', 'ryuumasann@gmail.com', 'password', ''),
 (4, 'Ryunosuke Matsuoka', 'ryuunosukematsuoka@gmail.com', 'password', '');
 
+-- 作成日時よりも120日前に作成する
 INSERT INTO projects (id, title, content, created_at) VALUES
 (1, '僕らのプロジェクト', '僕らのプロジェクトの内容', concat( date_sub(current_date(), interval 120 day))),
 (2, 'プロジェクト2', 'プロジェクト2の内容', concat( date_sub(current_date(), interval 120 day))),
 (3, 'プロジェクト3', 'プロジェクト3の内容', concat( date_sub(current_date(), interval 120 day))),
 (4, 'プロジェクト4', 'プロジェクト4の内容', concat( date_sub(current_date(), interval 120 day)));
 
+-- pending : 評価待ち、タスクの完了 = 評価待ち状態
 INSERT INTO status (id, name) VALUES
 (1, 'normal'),
 (2, 'danger'),
@@ -227,4 +229,4 @@ INSERT INTO tags (id, name) VALUES
 (2, '実装難易度'),
 (3, 'チーム貢献度'),
 (4, '報告のわかりやすさ'),
-(5, '実装速度')
+(5, '実装速度');


### PR DESCRIPTION
親タスク、子タスクの概念をデータベースに追加しました。

## 変更点

### scoresテーブルの削除
- 評価は1ポイントのためevaluation_tagsテーブルを使って集計すればOK

## 前回のテーブルへの影響

### evaluationsテーブル
- isEvaluatedカラムの削除

### evaluation-tagsテーブル
- isEvaluatedカラムの追加
- commentカラムの追加