### PR TITLE
PHPにてデータベースのデータを日本語で取得できるように変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,16 @@ services:
 
   mysql:
     container_name: mysql
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
     image: mysql:5.7
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: mydb
       MYSQL_USER: myuser
       MYSQL_PASSWORD: mypassword
+      TZ: Asia/Tokyo
     volumes:
       - ./mysql/data:/var/lib/mysql
+      - ./my.cnf:/etc/mysql/conf.d/my.cnf
     ports:
       - 3306:3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   php:
     container_name: php
@@ -6,6 +6,7 @@ services:
       context: .
       dockerfile: ./php/Dockerfile
     volumes:
+      - ./php/php.ini:/usr/local/etc/php/php.ini
       - ./src:/var/www/html
     ports:
       - 8080:80

--- a/manual.md
+++ b/manual.md
@@ -2,11 +2,19 @@
 
 ```bash
 docker-compose up -d
-docker-compose exec mysql mysql -u root -p mydb
+docker-compose exec mysql mysql -u root -p team_weekly_report
 ```
 
 ## 起動しない場合
 Docker UIの方で一旦動いているコンテナを停止してから再度上記コマンドを試す
+
+## Dockerfileまたはymlファイルが更新されたら
+
+```bash
+docker-compose up -d --build
+```
+
+上記コマンドでymlファイルの設定を更新する
 
 起動後にリンクを確認
 [http://localhost:8080](http://localhost:8080)

--- a/my.conf
+++ b/my.conf
@@ -1,0 +1,6 @@
+[mysqld]
+character-set-server=utf8
+collation-server=utf8_general_ci
+
+[client]
+default-character-set=utf8

--- a/php/php.ini
+++ b/php/php.ini
@@ -1,0 +1,5 @@
+[Date]
+date.timezone = "Asia/Tokyo"
+[mbstring]
+mbstring.internal_encoding = "UTF-8"
+mbstring.language = "Japanese"

--- a/src/how-to-select-db.php
+++ b/src/how-to-select-db.php
@@ -13,7 +13,7 @@ $conn = new PDO("mysql:host={$host};dbname={$dbName};", $user, $pwd);
 
 // 連想配列で取得するように設定
 $conn->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
-$pst = $conn->query('select * from users');
+$pst = $conn->query('select * from projects');
 $result = $pst->fetchAll();
 
 echo "<pre>";


### PR DESCRIPTION
それぞれ追加したファイルについて

## `php/php.ini`ファイル
- タイムゾーンをAsia/Tokyoに変更
- 文字セットをUTF-8かつJapaneseに

## `my.conf`ファイル
同様に文字セットとコレーションをutf8に変更

## `docker-compose.yml`ファイル
- php
  - volumesにphp.iniの設定を読み込ませる
- mysql
  - commandで文字セットをセットする
  - 環境変数にAsia/Tokyoのタイムゾーンを設定
  - volumesにmy.cnfの設定を読み込ませる
 
# 重要
ymlファイルやDockerfile変更後は以下のコマンドを実行してください

```bash
docker-compose up -d --build
```

上記コマンドじゃないと設定がコンテナに反映されません＞＜
